### PR TITLE
Arbitrary port

### DIFF
--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -32,6 +32,7 @@ from configuration_management import (
     filter_label_sizes_for_printer,
     filter_printers,
     normalize_default_fonts,
+    split_server_and_port,
     validate_configuration,
     compute_printer_selection,
 )
@@ -865,8 +866,14 @@ def validate_cups_server_api():
         payload = request.json or {}
         server = payload.get('server') or 'localhost'
         old_server = cups.getServer()
+        old_port = cups.getPort() if hasattr(cups, 'getPort') else None
+        if not isinstance(old_port, int):
+            old_port = None
+        server_host, server_port = split_server_and_port(server)
         try:
-            conn = cups.Connection(server)
+            cups.setServer(server_host)
+            cups.setPort(server_port)
+            conn = cups.Connection()
             printers = list(conn.getPrinters().keys())
             return {'success': True, 'server': server, 'printers': printers}
         except Exception as e:
@@ -874,6 +881,8 @@ def validate_cups_server_api():
             return {'success': False, 'error': str(e), 'server': server}
         finally:
             cups.setServer(old_server)
+            if old_port is not None:
+                cups.setPort(old_port)
     except Exception as e:
         response.status = 500
         logger.error(f"Error validating CUPS server: {e}")

--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -4,7 +4,6 @@
 """
 This is a web service to print labels on label printers via CUPS.
 """
-import cups
 import copy
 import textwrap
 
@@ -32,7 +31,6 @@ from configuration_management import (
     filter_label_sizes_for_printer,
     filter_printers,
     normalize_default_fonts,
-    split_server_and_port,
     validate_configuration,
     compute_printer_selection,
 )
@@ -863,26 +861,10 @@ def save_settings_api():
 def validate_cups_server_api():
     """Validate connectivity to a CUPS server without changing current config."""
     try:
-        payload = request.json or {}
-        server = payload.get('server') or 'localhost'
-        old_server = cups.getServer()
-        old_port = cups.getPort() if hasattr(cups, 'getPort') else None
-        if not isinstance(old_port, int):
-            old_port = None
-        server_host, server_port = split_server_and_port(server)
-        try:
-            cups.setServer(server_host)
-            cups.setPort(server_port)
-            conn = cups.Connection()
-            printers = list(conn.getPrinters().keys())
-            return {'success': True, 'server': server, 'printers': printers}
-        except Exception as e:
+        result = instance.validate_connectivity(request.json)
+        if not result.get('success'):
             response.status = 400
-            return {'success': False, 'error': str(e), 'server': server}
-        finally:
-            cups.setServer(old_server)
-            if old_port is not None:
-                cups.setPort(old_port)
+        return result
     except Exception as e:
         response.status = 500
         logger.error(f"Error validating CUPS server: {e}")

--- a/configuration_management.py
+++ b/configuration_management.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 # Configuration file path
 CONFIG_FILE = '/appconfig/config.json'
+DEFAULT_CUPS_PORT = 631
 
 # Default configuration structure
 DEFAULT_CONFIG = {
@@ -73,6 +74,27 @@ def label_sizes_list_to_dict(label_sizes_list, logger=None, warn_prefix=""):
             if logger:
                 logger.warning(f"{warn_prefix}Skipping invalid label size entry: {item}")
     return label_sizes_dict
+
+
+def split_server_and_port(server_value, default_port=DEFAULT_CUPS_PORT):
+    """
+    Split a CUPS server string into host and port.
+
+    Accepts values like "cups.local" or "cups.local:631". If no port is
+    included, the default CUPS port is returned.
+    """
+    if server_value is None:
+        return 'localhost', default_port
+
+    server = str(server_value).strip()
+    if not server:
+        return 'localhost', default_port
+
+    host, separator, port_text = server.rpartition(':')
+    if separator and host and port_text.isdigit():
+        return host, int(port_text)
+
+    return server, default_port
 
 
 def reload_config(config):

--- a/configuration_management.py
+++ b/configuration_management.py
@@ -90,6 +90,20 @@ def split_server_and_port(server_value, default_port=DEFAULT_CUPS_PORT):
     if not server:
         return 'localhost', default_port
 
+    # Handle bracketed IPv6 like "[::1]:631"
+    if server.startswith('['):
+        end = server.find(']')
+        if end != -1:
+            host = server[1:end]
+            rest = server[end + 1:]
+            if rest.startswith(':') and rest[1:].isdigit():
+                return host, int(rest[1:])
+            return host, default_port
+
+    # Raw IPv6 addresses contain multiple ':' and should not be split as host:port.
+    if server.count(':') > 1:
+        return server, default_port
+
     host, separator, port_text = server.rpartition(':')
     if separator and host and port_text.isdigit():
         return host, int(port_text)

--- a/implementation_cups.py
+++ b/implementation_cups.py
@@ -92,6 +92,29 @@ class implementation:
     def _get_conn(self):
         return cups.Connection()
 
+    def validate_connectivity(self, payload):
+        payload = payload or {}
+        server = payload.get('server') or 'localhost'
+
+        old_server = cups.getServer()
+        old_port = cups.getPort() if hasattr(cups, 'getPort') else None
+        if not isinstance(old_port, int):
+            old_port = None
+
+        server_host, server_port = split_server_and_port(server)
+        try:
+            cups.setServer(server_host)
+            cups.setPort(server_port)
+            conn = cups.Connection()
+            printers = list(conn.getPrinters().keys())
+            return {'success': True, 'server': server, 'printers': printers}
+        except Exception as e:
+            return {'success': False, 'error': str(e), 'server': server}
+        finally:
+            cups.setServer(old_server)
+            if old_port is not None:
+                cups.setPort(old_port)
+
     def _get_printer_name(self, printerName=None):
         if printerName:
             return printerName

--- a/implementation_cups.py
+++ b/implementation_cups.py
@@ -2,6 +2,7 @@
 import cups
 import re
 from constants import PARSEABLE_SIZE_PATTERN
+from configuration_management import split_server_and_port
 
 # Conversion constants
 POINTS_PER_INCH = 72.0  # PostScript/CUPS points per inch
@@ -40,6 +41,8 @@ class implementation:
         self.CONFIG = None
         self.logger = None
         self.server_ip = None
+        self.server_host = None
+        self.server_port = None
         self.selected_printer = None
         self.initialization_errors = []  # Track initialization and CUPS errors
         self.cups_default = None  # Track CUPS-reported default printer
@@ -49,6 +52,8 @@ class implementation:
         self.initialization_errors = []  # Clear any previous errors
         self.cups_default = None
         self.server_ip = None
+        self.server_host = None
+        self.server_port = None
 
         # Ensure PRINTER section exists and is a dict
         if 'PRINTER' not in self.CONFIG or self.CONFIG['PRINTER'] is None:
@@ -59,7 +64,9 @@ class implementation:
         if 'SERVER' in self.CONFIG['PRINTER']:
             self.server_ip = self.CONFIG['PRINTER']['SERVER']
 
-        cups.setServer(self.server_ip)
+        self.server_host, self.server_port = split_server_and_port(self.server_ip)
+        cups.setServer(self.server_host)
+        cups.setPort(self.server_port)
 
         # Test CUPS connection
         try:
@@ -69,7 +76,10 @@ class implementation:
             _ = conn.getPrinters()
             self.cups_default = conn.getDefault() or None
         except Exception as e:
-            error_msg = f"Failed to retrieve printer data from CUPS server at '{self.server_ip or 'localhost'}': {str(e)}"
+            server_display = self.server_ip or self.server_host or 'localhost'
+            if self.server_port:
+                server_display = f"{server_display}:{self.server_port}"
+            error_msg = f"Failed to retrieve printer data from CUPS server at '{server_display}': {str(e)}"
             self.cups_default = None
             self.initialization_errors.append(error_msg)
             print(f"Error: {error_msg}")

--- a/implementation_cups.py
+++ b/implementation_cups.py
@@ -76,7 +76,7 @@ class implementation:
             _ = conn.getPrinters()
             self.cups_default = conn.getDefault() or None
         except Exception as e:
-            server_display = self.server_ip or self.server_host or 'localhost'
+            server_display = self.server_host or 'localhost'
             if self.server_port:
                 server_display = f"{server_display}:{self.server_port}"
             error_msg = f"Failed to retrieve printer data from CUPS server at '{server_display}': {str(e)}"
@@ -94,6 +94,8 @@ class implementation:
 
     def validate_connectivity(self, payload):
         payload = payload or {}
+        if not isinstance(payload, dict):
+            payload = {}
         server = payload.get('server') or 'localhost'
 
         old_server = cups.getServer()

--- a/tests/test_configuration_management.py
+++ b/tests/test_configuration_management.py
@@ -44,6 +44,18 @@ class TestLabelSizesListToDict(unittest.TestCase):
         self.assertEqual(result, {'62': '62mm', '29': '29mm x 90mm'})
 
 
+class TestSplitServerAndPort(unittest.TestCase):
+    def test_returns_host_and_default_port_without_explicit_port(self):
+        host, port = cm.split_server_and_port('cups.local')
+        self.assertEqual(host, 'cups.local')
+        self.assertEqual(port, 631)
+
+    def test_parses_host_and_port(self):
+        host, port = cm.split_server_and_port('cups.local:8631')
+        self.assertEqual(host, 'cups.local')
+        self.assertEqual(port, 8631)
+
+
 class TestConfigToSettingsFormat(unittest.TestCase):
     """Test cases for config_to_settings_format function"""
 

--- a/tests/test_printer_defaults.py
+++ b/tests/test_printer_defaults.py
@@ -32,11 +32,31 @@ class TestPrinterDefaults(unittest.TestCase):
         }
 
         with patch("implementation_cups.cups.Connection", return_value=FakeConn()) as _conn, \
-             patch("implementation_cups.cups.setServer", create=True):
+             patch("implementation_cups.cups.setServer", create=True), \
+             patch("implementation_cups.cups.setPort", create=True):
             impl = implementation()
             impl.initialize(cfg)
 
         self.assertEqual(impl.selected_printer, "cups-default")
+        self.assertEqual(impl.initialization_errors, [])
+
+    def test_initialize_parses_server_port(self):
+        cfg = {
+            "PRINTER": {"USE_CUPS": True, "SERVER": "cups.local:8631", "PRINTER": ""},
+            "LABEL": {"DEFAULT_SIZE": "62", "DEFAULT_ORIENTATION": "standard", "DEFAULT_FONTS": []},
+        }
+
+        with patch("implementation_cups.cups.Connection", return_value=FakeConn()) as _conn, \
+             patch("implementation_cups.cups.setServer", create=True) as mock_set_server, \
+             patch("implementation_cups.cups.setPort", create=True) as mock_set_port:
+            impl = implementation()
+            impl.initialize(cfg)
+
+        mock_set_server.assert_called_with("cups.local")
+        mock_set_port.assert_called_with(8631)
+        self.assertEqual(impl.server_ip, "cups.local:8631")
+        self.assertEqual(impl.server_host, "cups.local")
+        self.assertEqual(impl.server_port, 8631)
         self.assertEqual(impl.initialization_errors, [])
 
     def test_validate_allows_missing_configured_printer_when_printers_exist(self):

--- a/views/settings.jinja2
+++ b/views/settings.jinja2
@@ -108,7 +108,7 @@
                   <div class="form-group">
                     <label class="col-sm-3 control-label">CUPS Server</label>
                     <div class="col-sm-9">
-                      <p class="help-block" style="margin-top: 0;">CUPS server address. Use 'localhost' for local CUPS, or IP address for remote.</p>
+                      <p class="help-block" style="margin-top: 0;">CUPS server address. Use 'localhost' for local CUPS, or an IP/hostname for remote. You may also include a port, such as 'cups.local:631'.</p>
                       <div class="input-group">
                         <input type="text" class="form-control" id="printerServer" placeholder="localhost">
                         <span class="input-group-btn">


### PR DESCRIPTION
This pull request adds support for specifying a custom port in the CUPS server address (e.g., `cups.local:8631`) throughout the application. It includes changes to configuration management, CUPS implementation, API validation, and documentation, along with new tests to ensure correct parsing and usage of the server and port.

**CUPS Server Host/Port Handling:**
* Added a `split_server_and_port` function in `configuration_management.py` to parse CUPS server strings and extract the host and port, defaulting to port 631 if not specified. (`[configuration_management.pyR79-R99](diffhunk://#diff-9456aa23bb0c23c2b065046e988e2581688cdba0c538376c2d682f17e6d8e05dR79-R99)`)
* Updated `implementation_cups.py` to use the parsed host and port when initializing and connecting to CUPS, including setting both via `cups.setServer` and `cups.setPort`. (`[[1]](diffhunk://#diff-48f9a235a71885aa2029df28de9dfe9312949749d5e2e5fa1680608e7b622e6aL62-R69)`, `[[2]](diffhunk://#diff-48f9a235a71885aa2029df28de9dfe9312949749d5e2e5fa1680608e7b622e6aR44-R45)`, `[[3]](diffhunk://#diff-48f9a235a71885aa2029df28de9dfe9312949749d5e2e5fa1680608e7b622e6aR55-R56)`)
* Improved error messages to display both host and port for easier debugging. (`[implementation_cups.pyL72-R82](diffhunk://#diff-48f9a235a71885aa2029df28de9dfe9312949749d5e2e5fa1680608e7b622e6aL72-R82)`)

**API and Validation Improvements:**
* Refactored the CUPS server validation API to use the new parsing logic and handle ports, improving error handling and response structure. (`[[1]](diffhunk://#diff-48f9a235a71885aa2029df28de9dfe9312949749d5e2e5fa1680608e7b622e6aR95-R117)`, `[[2]](diffhunk://#diff-de421af0299c557fa29364d4cc862f1da261c17cf0a962aae9036772208257fdL865-R867)`)

**Testing:**
* Added unit tests for `split_server_and_port` and for CUPS initialization with custom ports to ensure correct behavior. (`[[1]](diffhunk://#diff-f47b0fd0f66bc813aa823bb16ba0054790842a425e015ea821fa0ca7b051395bR47-R58)`, `[[2]](diffhunk://#diff-7ad1358cf53418ed7bd67cc8e4f4f2c3322408878806ddc29d94ce41feddb67eL35-R61)`)

**Documentation and UI:**
* Updated the settings UI help text to inform users they can specify a port in the CUPS server address. (`[views/settings.jinja2L111-R111](diffhunk://#diff-dec9a4511efb5b4057cd970e5a57b92ce169c03d0c92e4ef25da34802f79f608L111-R111)`)

**Code Cleanup:**
* Removed a direct `import cups` from `brother_ql_web.py` where no longer needed. (`[brother_ql_web.pyL7](diffhunk://#diff-de421af0299c557fa29364d4cc862f1da261c17cf0a962aae9036772208257fdL7)`)